### PR TITLE
Allows to pass in readonly arrays as possibleValues

### DIFF
--- a/src/base-immutable/base-immutable.ts
+++ b/src/base-immutable/base-immutable.ts
@@ -46,7 +46,7 @@ export const PropertyType = {
 export interface Property<T extends { [key: string]: any } = any> {
   name: keyof T;
   defaultValue?: any;
-  possibleValues?: any[];
+  possibleValues?: readonly any[];
   validate?: Validator | Validator[];
   type?: PropertyType;
   immutableClass?: ImmutableLike;


### PR DESCRIPTION
I'm using a readonly array in Pivot, and I'd like to pass it as the possibleValues of a property but I can't. We don't modify the possibleValues array anyway, better be as strict as possible then.