### PR TITLE
Fixed array validation on object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .idea/workspace.xml
 .idea/tasks.xml
 .idea/watcherTasks.xml
+.idea/dataSources.local.xml
+.idea/prettier.xml
+.idea/runConfigurations.xml
 node_modules/
 build/
 test/*.js

--- a/src/base-immutable/base-immutable.spec.ts
+++ b/src/base-immutable/base-immutable.spec.ts
@@ -264,4 +264,24 @@ describe('BaseImmutable', () => {
     // car.change('owners', 'foo');
     // car.change('some unknown prop', ['hello']);
   });
+
+  it('should validate array values when PropertyType is set', () => {
+    expect(() =>
+      Car.fromJS({
+        fuel: 'electric',
+        name: 'ford',
+        // @ts-ignore like the compiled code will
+        passengers: 'badString',
+      }),
+    ).toThrow('Car.passengers must be an Array');
+  });
+
+  it('should set PropertyType.ARRAY to empty array if not defined', () => {
+    expect(
+      Car.fromJS({
+        fuel: 'electric',
+        name: 'ford',
+      }),
+    ).toEqual({ fuel: 'electric', name: 'ford', passengers: [] });
+  });
 });

--- a/src/base-immutable/base-immutable.ts
+++ b/src/base-immutable/base-immutable.ts
@@ -207,6 +207,12 @@ export abstract class BaseImmutable<ValueType, JSType>
           }
         }
 
+        if (property.type === PropertyType.ARRAY) {
+          if (!Array.isArray(pv)) {
+            throw new Error(`${(this.constructor as any).name}.${propertyName} must be an Array`);
+          }
+        }
+
         const validate = property.validate;
         if (validate) {
           const validators: Validator[] = Array.isArray(validate) ? validate : [validate];

--- a/src/base-immutable/car.mock.ts
+++ b/src/base-immutable/car.mock.ts
@@ -49,6 +49,7 @@ export interface CarValue {
   createdOn?: Date;
   owners?: string[];
   driver?: Driver;
+  passengers?: string[];
 }
 
 export interface CarJS {
@@ -60,6 +61,7 @@ export interface CarJS {
   createdOn?: Date | string;
   owners?: string[];
   driver?: DriverJS;
+  passengers?: string[];
 }
 
 function ensureNonNegative(n: any): void {
@@ -108,6 +110,10 @@ export class Car extends BaseImmutable<CarValue, CarJS> {
       name: 'driver',
       defaultValue: Driver.POPE,
       immutableClass: Driver,
+    },
+    {
+      name: 'passengers',
+      type: PropertyType.ARRAY,
     },
   ];
 


### PR DESCRIPTION
Added validation for a property when specifying PropertyType.ARRAY which can cause errors when code is compiled and value is set incorrectly. 