### PR TITLE
Add readonly-implicit-fields rule

### DIFF
--- a/packages/eslint-plugin-immutable-class/src/index.ts
+++ b/packages/eslint-plugin-immutable-class/src/index.ts
@@ -16,6 +16,7 @@
  */
 
 import { declareImplicitFields } from './rules/declare-implicit-fields';
+import { readonlyImplicitFields } from './rules/readonly-implicit-fields';
 
 module.exports = {
   configs: {
@@ -23,10 +24,12 @@ module.exports = {
       plugins: ['immutable-class'],
       rules: {
         'immutable-class/declare-implicit-fields': 'error',
+        'immutable-class/readonly-implicit-fields': 'error',
       },
     },
   },
   rules: {
     'declare-implicit-fields': declareImplicitFields,
+    'readonly-implicit-fields': readonlyImplicitFields,
   },
 };

--- a/packages/eslint-plugin-immutable-class/src/rules/declare-implicit-fields.spec.ts
+++ b/packages/eslint-plugin-immutable-class/src/rules/declare-implicit-fields.spec.ts
@@ -83,6 +83,11 @@ ruleTester.run('declare-implicit-fields', declareImplicitFields, {
       public changeFoo! = (foo: string) => this;
       private changeFoo! = (foo: string) => this;
     }`,
+    `class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+      declare readonly foo: string;
+      public declare readonly foo: string;
+      private declare readonly foo: string;
+    }`,
 
     // Invalid cases but not inside of BaseImmutable inheritors
     `class MyClass extends NotImmutable {

--- a/packages/eslint-plugin-immutable-class/src/rules/readonly-implicit-fields.md
+++ b/packages/eslint-plugin-immutable-class/src/rules/readonly-implicit-fields.md
@@ -1,0 +1,57 @@
+# Ensure that implicit ImmutableClass properties and accessors are readonly (`readonly-implicit-fields`)
+
+## Rule details
+
+This rule ensures that immutable class properties and accessors that are implicitly defined by `BaseImmutable` are defined as `readonly`.
+
+### ❌ Incorrect
+
+```ts
+class MyClass extends BaseImmutable<MyValue, MyJS> {
+  declare propOne: string;
+  public declare propTwo: number;
+  propThree = new Date();
+
+  constructor(value: MyValue) {
+    super(value);
+  }
+
+  public declare getPropOne: () => string;
+  public declare changePropOne: (propOne: string) => MyClass;
+
+  declare getPropTwo: () => number;
+  changePropTwo = (propTwo: number) => this.change('propTwo', propTwo || 2);
+}
+BaseImmutable.finalize(MyClass);
+```
+
+### ✅ Correct
+
+```ts
+class MyClass extends BaseImmutable<MyValue, MyJS> {
+  declare readonly propOne: string;
+  public declare readonly propTwo: number;
+  propThree = new Date();
+
+  constructor(value: MyValue) {
+    super(value);
+  }
+
+  public declare readonly getPropOne: () => string;
+  public declare readonly changePropOne: (propOne: string) => MyClass;
+
+  declare readonly getPropTwo: () => number;
+  changePropTwo = (propTwo: number) => this.change('propTwo', propTwo || 2);
+}
+BaseImmutable.finalize(MyClass);
+```
+
+### Configuring
+
+```jsonc
+{
+  "rules": {
+    "immutable-class/readonly-implicit-fields": ["error"]
+  }
+}
+```

--- a/packages/eslint-plugin-immutable-class/src/rules/readonly-implicit-fields.spec.ts
+++ b/packages/eslint-plugin-immutable-class/src/rules/readonly-implicit-fields.spec.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2022 Imply Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+import { readonlyImplicitFields } from './readonly-implicit-fields';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('readonly-implicit-fields', readonlyImplicitFields, {
+  valid: [
+    // Various valid cases inside of Immutable Classes
+    `class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+      public declare readonly foo: string;
+      private readonly baz: number;
+      public readonly qux: () => void;
+      public getBaz = () => this.baz;
+      public changeBaz = (baz: number) => this;
+      public doStuff(): string { return 'stuff'; }
+    }`,
+    `class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+      declare readonly foo: string;
+      public declare readonly foo: string;
+      private declare readonly foo: string;
+    }`,
+    `class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+      declare readonly getFoo: () => string;
+      public declare readonly getFoo: () => string;
+      private declare readonly getFoo: () => string;
+    }`,
+    `class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+      declare readonly changeFoo: (foo: string) => MyClass;
+      public declare readonly changeFoo: (foo: string) => MyClass;
+      private declare readonly changeFoo: (foo: string) => MyClass;
+    }`,
+
+    // Invalid cases but not inside of BaseImmutable inheritors
+    `class MyClass extends NotImmutable {
+      declare foo: string;
+    }`,
+    `class MyClass extends NotImmutable {
+      public declare foo: string;
+    }`,
+    `class MyClass extends NotImmutable {
+      private declare foo: string;
+    }`,
+  ],
+  invalid: [
+    {
+      code: `
+        class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+          public declare foo: string;
+        }`,
+      errors: [{ messageId: 'useReadonlyForProperty', line: 3, column: 11 }],
+      output: `
+        class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+          public declare readonly foo: string;
+        }`,
+    },
+    {
+      code: `
+        class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+          declare foo: string;
+        }`,
+      errors: [{ messageId: 'useReadonlyForProperty', line: 3, column: 11 }],
+      output: `
+        class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+          declare readonly foo: string;
+        }`,
+    },
+    {
+      code: `
+        class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+          private declare foo: string;
+        }`,
+      errors: [{ messageId: 'useReadonlyForProperty', line: 3, column: 11 }],
+      output: `
+        class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+          private declare readonly foo: string;
+        }`,
+    },
+    {
+      code: `
+        class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+          public declare getFoo: () => string;
+        }`,
+      errors: [{ messageId: 'useReadonlyForAccessor', line: 3, column: 11 }],
+      output: `
+        class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+          public declare readonly getFoo: () => string;
+        }`,
+    },
+    {
+      code: `
+        class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+          declare getFoo: () => string;
+        }`,
+      errors: [{ messageId: 'useReadonlyForAccessor', line: 3, column: 11 }],
+      output: `
+        class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+          declare readonly getFoo: () => string;
+        }`,
+    },
+    {
+      code: `
+        class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+          private declare getFoo: () => string;
+        }`,
+      errors: [{ messageId: 'useReadonlyForAccessor', line: 3, column: 11 }],
+      output: `
+        class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+          private declare readonly getFoo: () => string;
+        }`,
+    },
+
+    // Weird spacing
+    {
+      code: `
+        class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+          public
+            declare foo          : string;
+        }`,
+      errors: [{ messageId: 'useReadonlyForProperty', line: 4, column: 13 }],
+      output: `
+        class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+          public
+            declare readonly foo          : string;
+        }`,
+    },
+  ],
+});

--- a/packages/eslint-plugin-immutable-class/src/rules/readonly-implicit-fields.ts
+++ b/packages/eslint-plugin-immutable-class/src/rules/readonly-implicit-fields.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Imply Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+  name =>
+    `https://github.com/implydata/immutable-class/blob/master/packages/eslint-plugin-immutable-class/src/rules/${name}.md`,
+);
+
+export const readonlyImplicitFields = createRule({
+  name: 'readonly-implicit-fields',
+  create(context) {
+    return {
+      PropertyDefinition(node) {
+        // Look for the containing class declaration
+        let cls = node.parent;
+        while (cls && cls.type !== AST_NODE_TYPES.ClassDeclaration) {
+          cls = cls.parent;
+        }
+
+        // Ensure the class is an Immutable class (derived from BaseImmutable)
+        if (!cls?.superClass) return;
+        if (cls.superClass.type !== AST_NODE_TYPES.Identifier) return;
+        if (cls.superClass.name !== 'BaseImmutable') return;
+
+        const invalid =
+          node.declare && // Using 'declare'
+          !node.readonly && // Not readonly
+          !node.static; // Not static
+
+        if (invalid) {
+          const messageId =
+            node.typeAnnotation?.typeAnnotation?.type === AST_NODE_TYPES.TSFunctionType
+              ? 'useReadonlyForAccessor'
+              : 'useReadonlyForProperty';
+
+          context.report({
+            messageId,
+            node,
+            *fix(fixer) {
+              // Insert 'readonly'
+              yield fixer.insertTextBefore(node.key, 'readonly ');
+            },
+          });
+        }
+      },
+    };
+  },
+  defaultOptions: [],
+  meta: {
+    docs: {
+      description: 'Ensure that implicit ImmutableClass properties and methods are readonly',
+      recommended: 'error',
+    },
+    messages: {
+      useReadonlyForProperty: 'Immutable class properties should be readonly',
+      useReadonlyForAccessor: 'Immutable class accessors should be readonly',
+    },
+    fixable: 'code',
+    type: 'problem',
+    schema: [],
+  },
+});


### PR DESCRIPTION
This adds another eslint rule, `readonly-implicit-fields` that ensures implicit fields that are defined with `declare` are also set as `readonly`.

I chose to make this a separate rule for the following reasons:
- Keep detection logic simple in `declare-implicit-fields`
- Allow disabling these rules individually should the need arise