### PR TITLE
Add 'declare' for some readonly properties (! or ?)

### DIFF
--- a/packages/eslint-plugin-immutable-class/src/rules/declare-implicit-fields.spec.ts
+++ b/packages/eslint-plugin-immutable-class/src/rules/declare-implicit-fields.spec.ts
@@ -274,6 +274,22 @@ ruleTester.run('declare-implicit-fields', declareImplicitFields, {
           public declare changeBar: (bar: string) => MyClass;
         }`,
     },
+    {
+      code: `
+        class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+          public readonly foo!: string;
+          public readonly bar?: number;
+        }`,
+      errors: [
+        { messageId: 'useDeclareForProperty', line: 3, column: 11 },
+        { messageId: 'useDeclareForProperty', line: 4, column: 11 },
+      ],
+      output: `
+        class MyClass extends BaseImmutable<MyClassValue, MyClassJS> {
+          public declare readonly foo: string;
+          public declare readonly bar?: number;
+        }`,
+    },
 
     // Weird spacing
     {


### PR DESCRIPTION
Expands the conditions for requiring `declare`:

When a property is `readonly` and either `!` or `?` are used, this usually indicates that it is not actually set in the constructor and therefore is set in BaseImmutable.