### PR TITLE
Allow properties to be configurable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5584,12 +5584,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/json5/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -5781,6 +5775,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -6910,12 +6910,6 @@
       "bin": {
         "json5": "lib/cli.js"
       }
-    },
-    "node_modules/tsconfig-paths/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
     },
     "node_modules/tsconfig-paths/node_modules/strip-bom": {
       "version": "3.0.0",
@@ -11513,14 +11507,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
       }
     },
     "kleur": {
@@ -11671,6 +11657,12 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -12484,12 +12476,6 @@
           "requires": {
             "minimist": "^1.2.0"
           }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
         },
         "strip-bom": {
           "version": "3.0.0",

--- a/packages/immutable-class/src/base-immutable/base-immutable.spec.ts
+++ b/packages/immutable-class/src/base-immutable/base-immutable.spec.ts
@@ -290,26 +290,35 @@ describe('BaseImmutable', () => {
     ).toEqual({ fuel: 'electric', name: 'ford', passengers: [] });
   });
 
-  it('should fail to construct if property defined without "delcare"', () => {
-    expect(() =>
-      Bicycle.fromJS({
-        fuel: 'potato',
-        name: 'riva',
-      }),
-    ).toThrow('Cannot redefine property: name');
+  it('should not fail to construct if property defined without "declare"', () => {
+    expect(() => Bicycle.fromJS({ fuel: 'potato', name: 'riva' })).not.toThrow();
+    expect(() => Bicycle.fromJS({ fuel: 'potato', name: 'RIVA' })).toThrow(
+      'Bicycle.name must be lowercase',
+    );
   });
 
-  it('should fail on get() if getter defined without "delcare"', () => {
+  it('should fail on get() if getter defined without "declare"', () => {
     const pope = Rider.fromJS({ name: 'pope' });
     expect(() => pope.get('name')).toThrowErrorMatchingInlineSnapshot(
       `"No getter was found for \\"name\\" but it is defined as a property. This might indicate that you are using \\"useDefineForClassFields\\" and forgot to use \\"declare\\" on an auto-generated getter property."`,
     );
   });
 
-  it('should fail on change() if changer defined without "delcare"', () => {
+  it('should fail on change() if changer defined without "declare"', () => {
     const pope = Rider.fromJS({ name: 'pope' });
     expect(() => pope.change('name', 'papa')).toThrowErrorMatchingInlineSnapshot(
       `"No changer was found for \\"name\\" but it is defined as a property. This might indicate that you are using \\"useDefineForClassFields\\" and forgot to use \\"declare\\" on an auto-generated getter property."`,
     );
+  });
+
+  it('allows values to be set in the constructor', () => {
+    let car = Car.fromJS({ name: 'ford', fuel: 'electric', range: 150 });
+
+    expect(car.get('name')).toEqual('ford');
+    expect(car.get('fuel')).toEqual('electric');
+    expect(car.getRange()).toEqual(200);
+
+    car = car.changeRange(0);
+    expect(car.getRange()).toEqual(0);
   });
 });

--- a/packages/immutable-class/src/base-immutable/base-immutable.ts
+++ b/packages/immutable-class/src/base-immutable/base-immutable.ts
@@ -118,10 +118,7 @@ export abstract class BaseImmutable<ValueType, JSType>
         if (property.type === PropertyType.DATE) {
           pv = new Date(pv);
         } else if (property.immutableClass) {
-          pv = (property.immutableClass as any).fromJS(
-            pv,
-            context ? contextTransform(context) : undefined,
-          );
+          pv = property.immutableClass.fromJS(pv, context ? contextTransform(context) : undefined);
         } else if (property.immutableClassArray) {
           if (!Array.isArray(pv)) throw new Error(`expected ${propertyName} to be an array`);
           const propertyImmutableClassArray: any = property.immutableClassArray;
@@ -178,7 +175,7 @@ export abstract class BaseImmutable<ValueType, JSType>
     for (const property of properties) {
       const propertyName = property.name;
       const propertyType = hasOwnProp(property, 'isDate') ? PropertyType.DATE : property.type;
-      const pv = (value as any)[propertyName];
+      const pv = value[propertyName];
 
       if (pv == null) {
         if (propertyType === PropertyType.ARRAY) {
@@ -202,7 +199,7 @@ export abstract class BaseImmutable<ValueType, JSType>
         }
 
         if (property.type === PropertyType.DATE) {
-          if (isNaN(pv)) {
+          if (isNaN(pv as any)) {
             throw new Error(`${this.constructor.name}.${propertyName} must be a Date`);
           }
         }
@@ -226,7 +223,7 @@ export abstract class BaseImmutable<ValueType, JSType>
 
       Object.defineProperty(this, propertyName, {
         value: pv,
-        configurable: false,
+        configurable: true,
         enumerable: true,
         writable: false,
       });

--- a/packages/immutable-class/src/base-immutable/bicycle.mock.ts
+++ b/packages/immutable-class/src/base-immutable/bicycle.mock.ts
@@ -72,9 +72,10 @@ export class Bicycle extends BaseImmutable<BicycleValue, BicycleJS> {
 
   constructor(params: BicycleValue) {
     super(params);
+    this.name = params.name;
   }
 
-  public name!: string; // This will cause a constructor error
+  public readonly name: string;
   public declare fuel: string;
 }
 BaseImmutable.finalize(Bicycle);

--- a/packages/immutable-class/src/base-immutable/car.mock.ts
+++ b/packages/immutable-class/src/base-immutable/car.mock.ts
@@ -139,11 +139,16 @@ export class Car extends BaseImmutable<CarValue, CarJS> {
   public declare name: string;
   public declare fuel: string;
   public declare subCar: Car;
-  public declare range: number;
+  public readonly range: number | undefined;
   public declare createdOn: Date;
 
   constructor(properties: CarValue) {
     super(properties);
+
+    if (properties.range != null) this.range = properties.range;
+    if (this.fuel === 'electric' && this.range && this.range < 200) {
+      this.range = 200;
+    }
   }
 
   public declare changeFuel: (fuel: string) => this;


### PR DESCRIPTION
In #28, I set `configurable: false` to catch errors where properties were defined without using `declare`, but this is too restrictive for real-world code. There are legitimate cases where some properties need to be defined conditionally within the constructor (rather than fromJS), so we should allow them to be re-defined by the runtime.

Here is the pattern:

```ts
class MyClass extends BaseImmutable<MyValue, MyJS> {
  public declare readonly foo: string;
  public readonly bar: number;

  constructor(properties: MyValue) {
    super(properties);
    this.bar = properties.foo === 'special' ? 42 : properties.bar;
  }
}
```

This might technically break the contract of ImmutableClass, but code like this exists where ImmutableClass is used, so we should tolerate it to avoid risky rewrites. Developers are still guided towards `declare` by the lint rule and omitting it for values that aren't explicitly set in the constructor will emit a TS error.